### PR TITLE
Require PHP 8.1+ and modernize codebase

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,6 @@
 name: Checks
 on:
+    workflow_dispatch:
     pull_request:
     push:
         branches:
@@ -12,7 +13,7 @@ jobs:
         steps:
             -
                 name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -31,12 +32,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+                php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -
                 name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -44,7 +45,7 @@ jobs:
                     php-version: ${{ matrix.php-version }}
             -
                 name: Update dependencies
-                run: composer update --no-progress --${{ matrix.dependency-version }} --no-interaction
+                run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             -
                 name: Run tests
                 run: composer check:tests

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "error identifier"
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.7.0",
@@ -22,8 +22,9 @@
         "phpstan/phpstan": "^2.1.17",
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-strict-rules": "^2.0.4",
-        "phpunit/phpunit": "^9.6.23",
-        "shipmonk/coding-standard": "^0.1.3",
+        "phpunit/phpunit": "^10.5.62 || ^11.5.50",
+        "shipmonk/coding-standard": "^0.2.0",
+        "shipmonk/composer-dependency-analyser": "^1.8.4",
         "shipmonk/phpstan-rules": "^4.1.2",
         "slevomat/coding-standard": "^8.18.0"
     },
@@ -54,13 +55,15 @@
             "@check:ec",
             "@check:cs",
             "@check:types",
-            "@check:tests"
+            "@check:tests",
+            "@check:dependencies"
         ],
         "check:composer": [
             "composer normalize --dry-run --no-check-lock --no-update-lock",
             "composer validate --strict"
         ],
         "check:cs": "phpcs",
+        "check:dependencies": "composer-dependency-analyser",
         "check:ec": "ec src tests",
         "check:tests": "phpunit tests",
         "check:types": "phpstan analyse -vv --ansi",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,9 +12,7 @@
     <exclude-pattern>tests/data/*</exclude-pattern>
 
     <config name="installed_paths" value="vendor/slevomat/coding-standard,vendor/shipmonk/coding-standard"/>
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80100"/>
 
-    <rule ref="ShipMonkCodingStandard">
-        <exclude name="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden"/><!-- It removes @dataProvider, but PHPUnit 9 does not yet have #[DataProvider] -->
-    </rule>
+    <rule ref="ShipMonkCodingStandard"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,11 +5,10 @@
          bootstrap="vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         cacheResultFile="cache/phpunit.result.cache"
+         beStrictAboutCoverageMetadata="true"
+         failOnAllIssues="true"
+         displayDetailsOnAllIssues="true"
+         cacheDirectory="cache/phpunit"
 >
     <php>
         <ini name="error_reporting" value="-1"/>

--- a/src/InlineIgnoreInliner.php
+++ b/src/InlineIgnoreInliner.php
@@ -5,18 +5,17 @@ namespace ShipMonk\PHPStan\Errors;
 use function explode;
 use function implode;
 use function rtrim;
+use function str_contains;
 use function strlen;
-use function strpos;
 use function substr;
 
 final class InlineIgnoreInliner
 {
 
-    private Io $io;
-
-    public function __construct(Io $io)
+    public function __construct(
+        private Io $io,
+    )
     {
-        $this->io = $io;
     }
 
     /**
@@ -26,7 +25,7 @@ final class InlineIgnoreInliner
      */
     public function inlineErrors(
         array $errors,
-        ?string $comment
+        ?string $comment,
     ): void
     {
         foreach ($errors as $filePath => $fileErrors) {
@@ -49,7 +48,7 @@ final class InlineIgnoreInliner
                     ? ''
                     : " ($comment)";
 
-                $append = strpos($lineContent, '// @phpstan-ignore ') !== false
+                $append = str_contains($lineContent, '// @phpstan-ignore ')
                     ? ', ' . $identifier . $resolvedComment
                     : ' // @phpstan-ignore ' . $identifier . $resolvedComment;
 

--- a/src/Io.php
+++ b/src/Io.php
@@ -9,8 +9,8 @@ use function getopt;
 use function in_array;
 use function is_array;
 use function is_string;
+use function str_starts_with;
 use function stream_get_contents;
-use function strpos;
 use const STDIN;
 
 class Io
@@ -24,7 +24,7 @@ class Io
     public function readCliComment(array $argv): ?string
     {
         foreach (array_slice($argv, 1) as $arg) {
-            if (strpos($arg, '--') === 0 && strpos($arg, '--comment') !== 0) {
+            if (str_starts_with($arg, '--') && !str_starts_with($arg, '--comment')) {
                 throw new FailureException('Unexpected option: ' . $arg);
             }
         }
@@ -86,7 +86,7 @@ class Io
      */
     public function writeFile(
         string $filePath,
-        string $contents
+        string $contents,
     ): void
     {
         if (file_put_contents($filePath, $contents) === false) {

--- a/tests/InlineIgnoreInlinerTest.php
+++ b/tests/InlineIgnoreInlinerTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\PHPStan\Errors;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use function file;
 use function file_get_contents;
@@ -14,12 +15,10 @@ use function uniqid;
 class InlineIgnoreInlinerTest extends TestCase
 {
 
-    /**
-     * @dataProvider lineEndingProvider
-     */
+    #[DataProvider('lineEndingProvider')]
     public function testInlineErrors(
         string $lineEnding,
-        ?string $comment
+        ?string $comment,
     ): void
     {
         $tmpFilePath = sys_get_temp_dir() . '/' . uniqid('ignore', true) . '.php';
@@ -60,7 +59,7 @@ class InlineIgnoreInlinerTest extends TestCase
 
     private function getTestFileContent(
         string $filename,
-        string $lineEnding
+        string $lineEnding,
     ): string
     {
         $content = file_get_contents(__DIR__ . '/data/' . $filename);

--- a/tests/IoTest.php
+++ b/tests/IoTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\PHPStan\Errors;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use function fclose;
 use function fwrite;
@@ -15,14 +16,13 @@ class IoTest extends TestCase
 
     /**
      * @param list<string> $args
-     *
-     * @dataProvider optionsProvider
      */
+    #[DataProvider('optionsProvider')]
     public function testCliOptions(
         int $exitCode,
         string $input,
         array $args,
-        string $expectedOutput
+        string $expectedOutput,
     ): void
     {
         $result = $this->runCliCommand($args, $input);
@@ -57,7 +57,7 @@ class IoTest extends TestCase
      */
     private function runCliCommand(
         array $args,
-        string $input
+        string $input,
     ): array
     {
         $binaryPath = __DIR__ . '/../bin/inline-phpstan-ignores';


### PR DESCRIPTION
Drops PHP 7.4/8.0 support and modernizes tooling and code to match recent ShipMonk OSS library upgrades (e.g. `name-collision-detector`, `phpstan-rules`).

## composer.json
- `php`: `^7.4 || ^8.0` → `^8.1`
- `phpunit/phpunit`: `^9.6.23` → `^10.5.62 || ^11.5.50`
- `shipmonk/coding-standard`: `^0.1.3` → `^0.2.0`
- Added `shipmonk/composer-dependency-analyser` + a `check:dependencies` step in the `check` script

## CI (`.github/workflows/checks.yml`)
- Dropped `7.4`/`8.0` from the test matrix (now `8.1`–`8.5`)
- `actions/checkout@v4` → `@v6`, added `workflow_dispatch` trigger, added `--prefer-dist` to the update step

## phpunit.xml.dist
- Migrated to the PHPUnit 10/11 schema: `beStrictAboutCoversAnnotation`→`beStrictAboutCoverageMetadata`, `failOnRisky`/`failOnWarning`→`failOnAllIssues`, added `displayDetailsOnAllIssues`, `cacheResultFile`→`cacheDirectory`

## phpcs.xml.dist
- `php_version` `70400` → `80100`
- Removed the `ForbiddenAnnotations` exclusion that only existed because PHPUnit 9 lacked `#[DataProvider]`

## Source & tests
- `InlineIgnoreInliner`: constructor property promotion; `strpos(...) !== false` → `str_contains()`
- `Io`: `strpos(...) === 0` → `str_starts_with()`
- Tests: `@dataProvider` → `#[DataProvider]` attributes
- Trailing commas in multi-line declarations (enforced by the new coding standard)

All checks pass on PHP 8.5 with both `prefer-stable` and `prefer-lowest`.

Co-Authored-By: Claude Code